### PR TITLE
Hotfix/text map

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -6,11 +6,13 @@ let log = debug('cs-plugin-vendor-ft:manifest')
 
 let storedFtData = null
 let storedImageMap = null
+let storedTextMap = null
 
 function parseFtData(context, build) {
 	// log('parseFtData()', context, build)
 	storedFtData = []
 	storedImageMap = null
+	storedTextMap = null
 	return new Promise((resolve, reject) => {
 		const pathFtData = context + '/' + build + '/common/js/data/FtData.js'
 		// log('pathFtData:', pathFtData)
@@ -38,6 +40,12 @@ function parseFtData(context, build) {
 					const stripVar = singleData.substr(singleData.indexOf('{'))
 					// store for later use on a per size basis
 					storedImageMap = JSON.parse(stripVar)
+				} else if (labelType == 'text-map') {
+					// strip comments
+					const singleData = dataMatches[i].replace(RegEx.lineComments, '')
+					const stripVar = singleData.substr(singleData.indexOf('{'))
+					// store for later use on a per size basis
+					storedTextMap = JSON.parse(stripVar)
 				} else {
 					// exec() is run on the regex itself, so it must be re-declared each time
 					let value = /\|\|([^\"\']*)([\"\'])((?:[^\2\\]|\\.)*?\2)/g.exec(dataMatches[i])
@@ -73,6 +81,22 @@ function parseFtDataImageMap(json, size) {
 		}
 		json['instantAds'].push({
 			type: 'image',
+			name: key,
+			default: val
+		})
+	}
+}
+
+function parseFtDataTextMap(json, size) {
+	for (let key in storedTextMap) {
+		let val = ''
+		if (size in storedTextMap[key]) {
+			val = storedTextMap[key][size]
+		} else if ('default' in storedTextMap[key]) {
+			val = storedTextMap[key]['default']
+		}
+		json['instantAds'].push({
+			type: 'text',
 			name: key,
 			default: val
 		})
@@ -136,6 +160,9 @@ function transform(dataRaw, buildData) {
 
 	// apply the imageMap
 	parseFtDataImageMap(manifestJSON, buildData['dimensions'].join('x'))
+
+	// apply the textMap
+	parseFtDataTextMap(manifestJSON, buildData['dimensions'].join('x'))
 
 	return manifestJSON
 }

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -158,11 +158,11 @@ function transform(dataRaw, buildData) {
 		manifestJSON['instantAds'].push(target)
 	})
 
-	// apply the imageMap
-	parseFtDataImageMap(manifestJSON, buildData['dimensions'].join('x'))
-
 	// apply the textMap
 	parseFtDataTextMap(manifestJSON, buildData['dimensions'].join('x'))
+
+	// apply the imageMap
+	parseFtDataImageMap(manifestJSON, buildData['dimensions'].join('x'))
 
 	return manifestJSON
 }

--- a/lib/packager.js
+++ b/lib/packager.js
@@ -146,7 +146,7 @@ function createVendorPackage(profile, context, folders, targets) {
 							fs.readFile(context + '/' + filePath + 'manifest.js', 'utf8', (err, dataRaw) => {
 								if (err) reject()
 								const manifestJSON = Manifest.transform(dataRaw, buildData)
-								// get the image map data
+								// get the image map data....and text map data?
 								const backToString = 'FT.manifest(' + JSON.stringify(manifestJSON) + ')'
 
 								// write into the zip


### PR DESCRIPTION
Added functionality to parse textMap into the Manifest file. Previously, it ignored textMap and would break the plugin's process of creating the deployed vendor files for FT.