### PR TITLE
added 'dynamic_images' to Filter.excludedFoldersList since all dynami…

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,5 +1,5 @@
 const excludedFilesList = ['.gitignore', '.DS_Store', '*.txt', 'manifest.js']
-const excludedFoldersList = ['instantAssets']
+const excludedFoldersList = ['instantAssets', 'dynamic_images']
 
 function excludedFiles(filename) {
 	for (let str of excludedFilesList) {


### PR DESCRIPTION
…c images in FT ads will be in the Flashtalking system and not included in the to_upload delivery zip.

This also prevents the 'common/dynamic_images/' to be copied to the to_upload delivery zip which is the intended behavior.